### PR TITLE
Stop channels before shutdown_kernel

### DIFF
--- a/voila/handler.py
+++ b/voila/handler.py
@@ -172,6 +172,19 @@ class VoilaHandler(JupyterHandler):
 
         self.executor = VoilaExecutor(nb, km=km, config=self.traitlet_config,
                                       show_tracebacks=self.voila_configuration.show_tracebacks)
+        
+        # Getting a reference to the original shutdown_kernel method
+        orig_shutdown_kernel = km.shutdown_kernel
+
+        # Defining a new shutdown_kernel method, that also stops client channels
+        async def shutdown_kernel(self, *args, executor=self.executor, **kwargs):
+            executor.kc.stop_channels()
+            await orig_shutdown_kernel(*args, **kwargs)
+
+        # Monkey patching the shutdown_kernel function
+        self.log.info("Monkey patching shutdown for kernel")
+        from jupyter_client import AsyncKernelManager
+        km.shutdown_kernel = shutdown_kernel.__get__(km, AsyncKernelManager)
 
         ###
         # start kernel client


### PR DESCRIPTION
This stops the client channels (joining their threads) before shutting down a kernel, mitigating a thread leak. It might make more sense to make this change upstream (in `jupyter_client`).