### PR TITLE
Remove custom thread cleanup function

### DIFF
--- a/voila/handler.py
+++ b/voila/handler.py
@@ -181,19 +181,6 @@ class VoilaHandler(JupyterHandler):
 
         self.executor = VoilaExecutor(nb, km=km, config=self.traitlet_config,
                                       show_tracebacks=self.voila_configuration.show_tracebacks)
-        
-        # Getting a reference to the original shutdown_kernel method
-        orig_shutdown_kernel = km.shutdown_kernel
-
-        # Defining a new shutdown_kernel method, that also stops client channels
-        async def shutdown_kernel(self, *args, executor=self.executor, **kwargs):
-            executor.kc.stop_channels()
-            await orig_shutdown_kernel(*args, **kwargs)
-
-        # Monkey patching the shutdown_kernel function
-        self.log.info("Monkey patching shutdown for kernel")
-        from jupyter_client import AsyncKernelManager
-        km.shutdown_kernel = shutdown_kernel.__get__(km, AsyncKernelManager)
 
         ###
         # start kernel client


### PR DESCRIPTION
This removes the custom thread cleanup function, which should no longer be needed as of Voila v0.14.0.